### PR TITLE
:fire: remove building svelte with sbt

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '18.18'
-          cache: 'npm'
+          cache: 'yarn'
           cache-dependency-path: 'frontend'
-      - run: npm install && npm run build
+      - run: yarn && yarn build
         working-directory: frontend

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@ There is an [openapi specification][openapi.yaml]. You can have a look with [Swa
 
 ## How to build and run
 
-First generate a `Dockerfile` with sbt through Docker:
+Build frontend files:
+
+```shell
+docker run --rm --tty \
+  --volume ./frontend:/home/node/seblm-meals \
+  --user node --workdir /home/node/seblm-meals \
+  node:18-alpine yarn
+docker run --rm --tty \
+  --volume ./frontend:/home/node/seblm-meals \
+  --user node --workdir /home/node/seblm-meals \
+  node:18-alpine yarn build
+```
+
+Generate a `Dockerfile` with sbt through Docker:
 
 ```shell
 docker run --rm --tty \
@@ -19,7 +32,7 @@ docker run --rm --tty \
 Then run compose:
 
 ```shell
-APPLICATION_UPDATE_DB=true docker compose up
+APPLICATION_UPDATE_DB=true docker compose up --detach
 ```
 
 Go to http://localhost:9000 and you are good to go. Please note that `APPLICATION_UPDATE_DB=true` is only required for
@@ -36,6 +49,18 @@ docker compose stop
 Please have a look to [specific documentation](backup/README.md).
 
 ## How to start application in dev mode
+
+You need to have `yarn` and `sbt` installed on your machine.
+
+### Frontend
+
+```shell
+cd frontend
+yarn
+yarn dev
+```
+
+### Backend
 
 Expose database by adding exposed ports into `compose.yaml`:
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import scala.sys.process.Process
-
 name := "seblm-meals"
 organization := "name.lemerdy.sebastian"
 
@@ -11,7 +9,6 @@ lazy val root = (project in file("."))
   .enablePlugins(DockerPlugin, PlayScala)
   .settings(
     Assets / unmanagedResourceDirectories += baseDirectory.value / "frontend" / "build",
-    Docker / stage := (Docker / stage dependsOn npmBuildTask).value,
     dockerBaseImage := "eclipse-temurin:17",
     dockerExposedPorts := Seq(9000),
     dockerEnvVars := Map(
@@ -21,15 +18,6 @@ lazy val root = (project in file("."))
       "POSTGRESQL_ADDON_HOST" -> "",
       "POSTGRESQL_ADDON_DB" -> ""
     ),
-    npmBuildTask := {
-      val dir = baseDirectory.value / "frontend"
-      if (
-        !((baseDirectory.value / "frontend" / "node_modules").exists() || Process("npm install", dir).! == 0) ||
-        Process("npm run build", dir).! != 0
-      ) {
-        throw new Exception("Build failed!")
-      }
-    },
     routesImport += "meals.application.MealsBinders._",
     routesImport += "java.time.{LocalDateTime, Year}",
     routesImport += "java.util.UUID",


### PR DESCRIPTION
Fixes #181 

This was a bad idea to use `sbt` to run `npm run build`.