### PR TITLE
:construction_worker: Publish a docker image with latest tag for each push to main

### DIFF
--- a/.github/workflows/seblm-meals.yml
+++ b/.github/workflows/seblm-meals.yml
@@ -75,6 +75,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: seblm/seblm-meals
+          tags: latest
       - uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
- fixes #191 